### PR TITLE
feat: get all todo for user

### DIFF
--- a/controllers/todo/getAllTodo.controller.js
+++ b/controllers/todo/getAllTodo.controller.js
@@ -1,0 +1,17 @@
+import TodoModel from "../../models/todo.model.js";
+
+async function getAllTodo(req, res) {
+    const { todoId } = req.params;
+    const { userId } = req.user;
+
+    try {
+        const todos = await TodoModel.find(
+            { user: userId },
+        );
+        return res.status(200).json({ message: 'Successful Operation', todos: todos });
+    } catch (err) {
+        return res.status(500).json({ message: err.message });
+    }
+}
+
+export default getAllTodo;

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,10 +1,11 @@
 import express from 'express';
 import userRouter from './user.route.js';
 import todoRouter from './todo.route.js';
+import validateToken from '../middlewares/validate_token.js';
 
 const router = express.Router()
 
-router.use('/todo', todoRouter);
+router.use('/todo',validateToken, todoRouter);
 
 router.use('/user', userRouter);
 

--- a/routes/todo.route.js
+++ b/routes/todo.route.js
@@ -1,22 +1,25 @@
 import express from "express";
-import validateToken from "../middlewares/validate_token.js";
 import updateTodo from "../controllers/todo/updateTodo.controller.js";
 import createTodo from "../controllers/todo/createTodo.controller.js";
 import getTodo from "../controllers/todo/getTodo.controller.js";
 import deleteToken from "../controllers/todo/deleteTodo.controller.js";
+import getAllTodo from "../controllers/todo/getAllTodo.controller.js";
 
 const todoRouter = express.Router();
 
 // Add a new todo for a login user
-todoRouter.post('/', validateToken, createTodo);
+todoRouter.post('/', createTodo);
 
 // Update an existing todo for a login user
-todoRouter.put('/:todoId', validateToken, updateTodo);
+todoRouter.put('/:todoId', updateTodo);
 
 // get an existing todo for a login user
-todoRouter.get('/:todoId', validateToken, getTodo);
+todoRouter.get('/:todoId', getTodo);
+
+// get all user todos
+todoRouter.get('/', getAllTodo);
 
 // delete a todo for a login user
-todoRouter.delete('/:todoId', validateToken, deleteToken);
+todoRouter.delete('/:todoId', deleteToken);
 
 export default todoRouter;


### PR DESCRIPTION
This pull request adds a new endpoint that allows users to get all todos associated with their account. The endpoint is accessible at /todo and requires a valid JWT token in the Authorization header.

The endpoint returns an array of todos that belong to the authenticated user. Each todo contains the title, description, createdAt, updatedAt, and id fields.